### PR TITLE
Fix IndexedDB cleanup

### DIFF
--- a/app/lib/hooks/useIndexedDB.ts
+++ b/app/lib/hooks/useIndexedDB.ts
@@ -46,13 +46,15 @@ export function useIndexedDB() {
     };
 
     initDB();
+  }, []);
 
+  useEffect(() => {
     return () => {
       if (db) {
         db.close();
       }
     };
-  }, []);
+  }, [db]);
 
   return { db, isLoading, error };
 }

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -2,6 +2,9 @@ import type { ServerBuild } from '@remix-run/cloudflare';
 import { createPagesFunctionHandler } from '@remix-run/cloudflare-pages';
 
 export const onRequest: PagesFunction = async (context) => {
+  // build directory is generated at runtime, so ignore TypeScript resolution
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   const serverBuild = (await import('../build/server')) as unknown as ServerBuild;
 
   const handler = createPagesFunctionHandler({


### PR DESCRIPTION
## Summary
- ensure the IndexedDB hook closes the db connection when the component unmounts
- ignore type-checking for the build/server runtime import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683ff6c3fb4483289752a2ba6b3ac8a7