### PR TITLE
Add login/pricing pages and sidebar links

### DIFF
--- a/app/components/sidebar/Menu.client.tsx
+++ b/app/components/sidebar/Menu.client.tsx
@@ -309,6 +309,10 @@ export const Menu = () => {
   };
 
   const handleSettingsClick = () => {
+    if (!profile?.username) {
+      window.location.href = '/login';
+      return;
+    }
     setIsSettingsOpen(true);
     setOpen(false);
   };
@@ -393,6 +397,20 @@ export const Menu = () => {
                 onChange={handleSearchChange}
                 aria-label="Search chats"
               />
+            </div>
+            <div className="flex gap-2">
+              <a
+                href="/login"
+                className="flex-1 text-center text-sm bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg px-4 py-2 transition-colors"
+              >
+                Login
+              </a>
+              <a
+                href="/pricing"
+                className="flex-1 text-center text-sm bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg px-4 py-2 transition-colors"
+              >
+                Pricing
+              </a>
             </div>
           </div>
           <div className="flex items-center justify-between text-sm px-4 py-2">

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,51 @@
+import { json, type ActionFunction, type MetaFunction } from '@remix-run/cloudflare';
+import { Form, useActionData } from '@remix-run/react';
+import { useEffect } from 'react';
+import { updateProfile } from '~/lib/stores/profile';
+import { Header } from '~/components/header/Header';
+import BackgroundRays from '~/components/ui/BackgroundRays';
+
+export const meta: MetaFunction = () => [{ title: 'Login - Blossom AI' }];
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData();
+  const username = formData.get('username');
+  if (typeof username === 'string' && username.trim() !== '') {
+    return json({ username });
+  }
+  return json({});
+};
+
+export default function Login() {
+  const data = useActionData<typeof action>();
+
+  useEffect(() => {
+    if (data?.username) {
+      updateProfile({ username: data.username });
+      window.location.href = '/';
+    }
+  }, [data]);
+
+  return (
+    <div className="flex flex-col h-full w-full bg-bolt-elements-background-depth-1">
+      <BackgroundRays />
+      <Header />
+      <div className="flex-1 flex items-center justify-center p-6">
+        <Form method="post" className="space-y-4 bg-white dark:bg-gray-950 p-6 rounded-lg shadow">
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Login</h1>
+          <input
+            name="username"
+            className="border border-gray-300 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 rounded px-3 py-2 text-gray-900 dark:text-gray-100 w-64"
+            placeholder="Username"
+          />
+          <button
+            type="submit"
+            className="bg-purple-600 text-white rounded px-4 py-2 hover:bg-purple-700 transition-colors"
+          >
+            Login
+          </button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/pricing.tsx
+++ b/app/routes/pricing.tsx
@@ -1,0 +1,17 @@
+import type { MetaFunction } from '@remix-run/cloudflare';
+import { Header } from '~/components/header/Header';
+import BackgroundRays from '~/components/ui/BackgroundRays';
+
+export const meta: MetaFunction = () => [{ title: 'Pricing - Blossom AI' }];
+
+export default function Pricing() {
+  return (
+    <div className="flex flex-col h-full w-full bg-bolt-elements-background-depth-1">
+      <BackgroundRays />
+      <Header />
+      <div className="flex-1 flex items-center justify-center p-6">
+        <p className="text-lg text-gray-900 dark:text-gray-100">Blossom AI is currently free while in early development.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/login` and `/pricing` routes
- link Login and Pricing from the sidebar nav
- restrict settings to logged-in users by redirecting to Login when needed

## Testing
- `pnpm lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403eb3e9d083289d2cbecc20ee4772